### PR TITLE
Update Maven build command to use 'verify'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,4 +42,4 @@ jobs:
           restore-keys: ${{ runner.os }}-maven
 
       - name: Build with Maven
-        run: ./mvnw clean install -DskipTests=false
+        run: ./mvnw clean verify


### PR DESCRIPTION
Change the Maven build command from 'install' to 'verify' to ensure proper verification of the project before deployment.